### PR TITLE
Refactor Domain

### DIFF
--- a/src/main/kotlin/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/domain/repository/UserRepository.kt
@@ -4,7 +4,7 @@ import org.example.domain.model.User
 import java.util.UUID
 
 interface UserRepository {
-    fun createUser(user: User, createdBy: User): Result<User>
+    fun createUser(user: User): Result<User>
     fun updateUser(user: User): Result<User>
     fun deleteUser(userId: UUID): Result<User>
     fun getUserById(userId: UUID): Result<User>

--- a/src/main/kotlin/domain/usecase/audit/GetAllAuditLogsUseCase.kt
+++ b/src/main/kotlin/domain/usecase/audit/GetAllAuditLogsUseCase.kt
@@ -2,11 +2,10 @@ package org.example.domain.usecase.audit
 
 import org.example.domain.model.AuditLog
 import org.example.domain.repository.AuditRepository
-import java.util.UUID
 
-class GetProjectAuditUseCase(
+class GetAllAuditLogsUseCase(
     private val auditRepository: AuditRepository
 ) {
-    fun getProjectAuditLogsById(projectId: UUID): Result<List<AuditLog>> =
-        auditRepository.getProjectAuditLogById(projectId)
+    fun getAllAuditLogs(): Result<List<AuditLog>> =
+         auditRepository.getAuditLogs()
 }

--- a/src/main/kotlin/domain/usecase/audit/GetTaskAuditUseCase.kt
+++ b/src/main/kotlin/domain/usecase/audit/GetTaskAuditUseCase.kt
@@ -4,9 +4,9 @@ import org.example.domain.model.AuditLog
 import org.example.domain.repository.AuditRepository
 import java.util.UUID
 
-class GetProjectAuditUseCase(
+class GetTaskAuditUseCase(
     private val auditRepository: AuditRepository
 ) {
-    fun getProjectAuditLogsById(projectId: UUID): Result<List<AuditLog>> =
-        auditRepository.getProjectAuditLogById(projectId)
+    fun getTaskAuditLogsById(taskId: UUID): Result<List<AuditLog>> =
+        auditRepository.getTaskAuditLogById(taskId)
 }

--- a/src/main/kotlin/domain/usecase/auth/RegisterUseCase.kt
+++ b/src/main/kotlin/domain/usecase/auth/RegisterUseCase.kt
@@ -1,49 +1,15 @@
 package org.example.domain.usecase.auth
 
-import org.example.data.storage.SessionManger
-import org.example.domain.exception.EiffelFlowException
 import org.example.domain.model.RoleType
 import org.example.domain.model.User
 import org.example.domain.repository.UserRepository
 import kotlin.Result
 
 class RegisterUseCase(
-    private val userRepository: UserRepository,
-    private val hashPasswordUseCase: HashPasswordUseCase
+    private val userRepository: UserRepository, private val hashPasswordUseCase: HashPasswordUseCase
 ) {
-    fun register(username: String, password: String, role: RoleType): Result<User> {
-        if (!SessionManger.isAdmin()) {
-            return Result.failure(EiffelFlowException.AuthorizationException("Only admins can register users."))
-        }
-
-        val availabilityCheck = checkUsernameAvailability(username)
-        if (availabilityCheck.isFailure) return Result.failure(availabilityCheck.exceptionOrNull()!!)
-
-        return createUser(username, password, role)
-    }
-
-    private fun checkUsernameAvailability(username: String): Result<Unit> {
-        val usersResult = userRepository.getUsers()
-        return usersResult.fold(
-            onSuccess = {onCheckUsernameAvailability(username = username, existingUsers = it)},
-            onFailure = { Result.failure(it) }
-        )
-    }
-
-    private fun onCheckUsernameAvailability(username: String, existingUsers: List<User>): Result<Unit> {
-        return if (existingUsers.any { it.username.equals(username, ignoreCase = true) }) {
-            Result.failure(EiffelFlowException. AuthorizationException("Username '$username' is already taken. Please choose another username."))
-        } else {
-            Result.success(Unit)
-        }
-    }
-
-    private fun createUser(username: String, password: String, role: RoleType): Result<User> {
+    fun register(username: String, password: String, userRole: RoleType): Result<User> {
         val hashedPassword = hashPasswordUseCase.hashPassword(password)
-
-        return userRepository.createUser(
-            user = User(username = username, password = hashedPassword, role = role),
-            createdBy = SessionManger.getUser()
-        )
+        return userRepository.createUser(user = User(username = username, password = hashedPassword, role = userRole))
     }
 }

--- a/src/main/kotlin/domain/usecase/project/DeleteProjectUseCase.kt
+++ b/src/main/kotlin/domain/usecase/project/DeleteProjectUseCase.kt
@@ -5,7 +5,5 @@ import org.example.domain.repository.ProjectRepository
 import java.util.UUID
 
 class DeleteProjectUseCase(private val projectRepository: ProjectRepository) {
-    fun deleteProject(projectId: UUID): Result<Project>{
-        TODO("Not yet implemented")
-    }
+    fun deleteProject(projectId: UUID): Result<Project> = projectRepository.deleteProject(projectId)
 }

--- a/src/main/kotlin/domain/usecase/task/EditTaskUseCase.kt
+++ b/src/main/kotlin/domain/usecase/task/EditTaskUseCase.kt
@@ -1,12 +1,11 @@
 package org.example.domain.usecase.task
 
 import org.example.domain.model.Task
-import org.example.domain.model.User
 import org.example.domain.exception.EiffelFlowException
 import org.example.domain.repository.TaskRepository
 
 class EditTaskUseCase(private val taskRepository: TaskRepository) {
-    fun editTask(request: Task, editor: User): Result<Task> {
+    fun editTask(request: Task): Result<Task> {
         val taskResult = taskRepository.getTaskById(request.taskId)
         if (taskResult.isFailure) return taskResult
 

--- a/src/test/kotlin/domain/usecase/audit/GetAllAuditLogsUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/audit/GetAllAuditLogsUseCaseTest.kt
@@ -1,0 +1,45 @@
+package domain.usecase.audit
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.example.domain.exception.EiffelFlowException
+import org.example.domain.repository.AuditRepository
+import org.example.domain.usecase.audit.GetAllAuditLogsUseCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.MockAuditLog
+
+class GetAllAuditLogsUseCaseTest {
+
+    private val auditRepository: AuditRepository = mockk()
+    private lateinit var getAllAuditLogsUseCase: GetAllAuditLogsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        getAllAuditLogsUseCase = GetAllAuditLogsUseCase(auditRepository)
+    }
+
+    @Test
+    fun `should return Result of list with all AuditLogs when logs exist`() {
+        every {
+            auditRepository.getAuditLogs()
+        } returns Result.success(listOf(MockAuditLog.AUDIT_LOG))
+
+        val result = getAllAuditLogsUseCase.getAllAuditLogs()
+
+        assertThat(result.getOrNull()).containsExactly(MockAuditLog.AUDIT_LOG)
+    }
+
+    @Test
+    fun `should return Result of NotFoundException when no logs exist`() {
+        val exception = EiffelFlowException.NotFoundException("Audit logs not found")
+        every {
+            auditRepository.getAuditLogs()
+        } returns Result.failure(exception)
+
+        val result = getAllAuditLogsUseCase.getAllAuditLogs()
+
+        assertThat(result.exceptionOrNull()).isEqualTo(exception)
+    }
+}

--- a/src/test/kotlin/domain/usecase/audit/GetTaskAuditUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/audit/GetTaskAuditUseCaseTest.kt
@@ -5,31 +5,31 @@ import io.mockk.every
 import io.mockk.mockk
 import org.example.domain.exception.EiffelFlowException
 import org.example.domain.repository.AuditRepository
-import org.example.domain.usecase.audit.GetProjectAuditUseCase
+import org.example.domain.usecase.audit.GetTaskAuditUseCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import utils.MockAuditLog
-import utils.ProjectsMock
+import utils.TaskMock
 
-class GetProjectAuditUseCaseTest {
+class GetTaskAuditUseCaseTest {
 
     private val auditRepository: AuditRepository = mockk()
-    private lateinit var getProjectAuditUseCase: GetProjectAuditUseCase
+    private lateinit var getTaskAuditUseCase: GetTaskAuditUseCase
 
     @BeforeEach
     fun setUp() {
-        getProjectAuditUseCase = GetProjectAuditUseCase(auditRepository)
+        getTaskAuditUseCase = GetTaskAuditUseCase(auditRepository)
     }
 
     @Test
-    fun `should return Result of list with AuditLogs when project with given id exists`() {
+    fun `should return Result of list with AuditLogs when task with given id exists`() {
         // Given
         every {
-            auditRepository.getProjectAuditLogById(any())
+            auditRepository.getTaskAuditLogById(any())
         } returns Result.success(listOf(MockAuditLog.AUDIT_LOG))
 
         // When
-        val result = getProjectAuditUseCase.getProjectAuditLogsById(ProjectsMock.CORRECT_PROJECT.projectId)
+        val result = getTaskAuditUseCase.getTaskAuditLogsById(TaskMock.mockTaskId)
 
         // Then
         assertThat(result.isSuccess).isTrue()
@@ -37,19 +37,18 @@ class GetProjectAuditUseCaseTest {
     }
 
     @Test
-    fun `should return Result of ElementNotFoundException when project with given id does not exist`() {
+    fun `should return Result of ElementNotFoundException when task with given id does not exist`() {
         // Given
-        val exception = EiffelFlowException.NotFoundException("Project not found")
+        val exception = EiffelFlowException.NotFoundException("Task not found")
         every {
-            auditRepository.getProjectAuditLogById(any())
+            auditRepository.getTaskAuditLogById(any())
         } returns Result.failure(exception)
 
         // When
-        val result = getProjectAuditUseCase.getProjectAuditLogsById(ProjectsMock.CORRECT_PROJECT.projectId)
+        val result = getTaskAuditUseCase.getTaskAuditLogsById(TaskMock.mockTaskId)
 
         // Then
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull()).isEqualTo(exception)
     }
-
 }

--- a/src/test/kotlin/domain/usecase/project/DeleteProjectUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/project/DeleteProjectUseCaseTest.kt
@@ -23,49 +23,40 @@ class DeleteProjectUseCaseTest {
     }
 
     @Test
-    fun `should return the deleted project when project gets deleted successfully`(){
-        try {
-            // Given
-            val projectId = UUID.fromString("02ad4499-5d4c-4450-8fd1-8294f1bb5748")
-            every { projectRepository.deleteProject(any()) } returns Result.success(correctProject)
+    fun `should return the deleted project when project gets deleted successfully`() {
+        // Given
+        val projectId = UUID.fromString("02ad4499-5d4c-4450-8fd1-8294f1bb5748")
+        every { projectRepository.deleteProject(any()) } returns Result.success(correctProject)
 
-            // When
-            val result = deleteProjectUseCase.deleteProject(projectId)
+        // When
+        val result = deleteProjectUseCase.deleteProject(projectId)
 
-            // Then
-            assertThat(result.isSuccess).isTrue()
-            verify {projectRepository.deleteProject(any())}
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify { projectRepository.deleteProject(any()) }
 
-        }catch (e: NotImplementedError) {
-            assertThat(e.message).contains("Not yet implemented")
-        }
     }
 
     @Test
-    fun `should return an UnableToFindTheCorrectProject exception when the project doesn't get deleted`(){
-        try {
-            // Given
-            val differentProjectId = UUID.fromString("11111111-1111-1111-1111-111111111111")
-            every { projectRepository.deleteProject(any()) } returns
-                    Result.failure(
-                        EiffelFlowException.IOException("unable to find correct project")
-                    )
+    fun `should return an UnableToFindTheCorrectProject exception when the project doesn't get deleted`() {
+        // Given
+        val differentProjectId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        every { projectRepository.deleteProject(any()) } returns
+                Result.failure(
+                    EiffelFlowException.IOException("unable to find correct project")
+                )
 
-            // When
-            val result = projectRepository.deleteProject(differentProjectId)
+        // When
+        val result = projectRepository.deleteProject(differentProjectId)
 
-            // Then
-            assertThat(result.isFailure).isTrue()
-            assertThat(result.exceptionOrNull()).isInstanceOf(
-                EiffelFlowException.IOException::class.java
-            )
-
-        }catch (e: NotImplementedError) {
-            assertThat(e.message).contains("Not yet implemented")
-        }
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(
+            EiffelFlowException.IOException::class.java
+        )
     }
 
-    companion object{
+    companion object {
         private val correctProject = ProjectsMock.CORRECT_PROJECT
     }
 

--- a/src/test/kotlin/domain/usecase/task/EditTaskUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/task/EditTaskUseCaseTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import utils.TaskMock.inProgressTask
 import utils.TaskMock.validTask
-import utils.UserMock.validUser
 import java.util.*
 
 class EditTaskUseCaseTest {
@@ -34,7 +33,7 @@ class EditTaskUseCaseTest {
             inProgressTask
         )
 
-        val result = editTaskUseCase.editTask(inProgressTask, validUser)
+        val result = editTaskUseCase.editTask(inProgressTask)
 
         assertThat(result.getOrNull()).isEqualTo(inProgressTask)
         assertThat(result.isSuccess).isTrue()
@@ -49,7 +48,7 @@ class EditTaskUseCaseTest {
         val exception = EiffelFlowException.IOException(null)
         every { taskRepository.getTaskById(validTask.taskId) } returns Result.success(validTask)
 
-        val result = editTaskUseCase.editTask(validTask, validUser)
+        val result = editTaskUseCase.editTask(validTask)
 
         assertThat(result.exceptionOrNull()).isInstanceOf(exception::class.java)
     }
@@ -59,7 +58,7 @@ class EditTaskUseCaseTest {
         val exception = EiffelFlowException.NotFoundException("Task not found")
         every { taskRepository.getTaskById(validTask.taskId) } returns Result.failure(exception)
 
-        val result = editTaskUseCase.editTask(validTask, validUser)
+        val result = editTaskUseCase.editTask(validTask)
 
         assertThat(result.exceptionOrNull()).isInstanceOf(exception::class.java)
     }
@@ -74,7 +73,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -98,7 +97,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -121,7 +120,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -145,7 +144,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -169,7 +168,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -193,7 +192,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 
@@ -215,7 +214,7 @@ class EditTaskUseCaseTest {
 
         every { taskRepository.getTaskById(updatedTask.taskId) } returns Result.success(originalTask)
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.exceptionOrNull()).isInstanceOf(EiffelFlowException.IOException::class.java)
     }
@@ -232,7 +231,7 @@ class EditTaskUseCaseTest {
             updatedTask
         )
 
-        val result = editTaskUseCase.editTask(updatedTask, validUser)
+        val result = editTaskUseCase.editTask(updatedTask)
 
         assertThat(result.getOrNull()).isEqualTo(updatedTask)
 


### PR DESCRIPTION
- Refactor `RegisterUseCase` and `UserRepository` to simplify user creation logic and enforce admin checks
- Add `GetAllAuditLogsUseCase` , `GetTaskAuditUseCase` and corresponding tests
- Refactor `GetProjectAuditUseCase` and  
- Refactor `EditTaskUseCase`
- Refactor `TaskRepositoryImpl`
