### PR TITLE
Move Task Audit Logs to Use cases

### DIFF
--- a/src/main/kotlin/di/CSVModule.kt
+++ b/src/main/kotlin/di/CSVModule.kt
@@ -27,8 +27,7 @@ val csvModule = module {
     single<TaskRepository> {
         TaskRepositoryImpl(
             taskCsvParser = get<TaskCsvParser>(),
-            fileDataSource = FileDataSource(File(TaskRepositoryImpl.FILE_NAME)),
-            auditRepository = get()
+            fileDataSource = FileDataSource(File(TaskRepositoryImpl.FILE_NAME))
         )
     }
     single<UserRepository> {

--- a/src/main/kotlin/di/MongoModule.kt
+++ b/src/main/kotlin/di/MongoModule.kt
@@ -35,8 +35,7 @@ val mongoModule = module{
     }
     single<TaskRepository> {
         MongoTaskRepositoryImpl(
-            database = get(),
-            auditRepository = get()
+            database = get()
         )
     }
     single<UserRepository> {

--- a/src/main/kotlin/di/UseCasesModule.kt
+++ b/src/main/kotlin/di/UseCasesModule.kt
@@ -16,11 +16,11 @@ val useCasesModule = module {
     factory { HashPasswordUseCase() }
     factory { RegisterUseCase(get(), get()) }
     single { GetProjectUseCase(get()) }
-    single { CreateTaskUseCase(get()) }
+    single { CreateTaskUseCase(get(),get()) }
     single { CreateProjectUseCase(get(),get()) }
     single { LoginUseCase(get()) }
     single { GetProjectAuditUseCase(get()) }
     single { DeleteProjectUseCase(get(),get()) }
     single { UpdateProjectUseCase(get(),get()) }
-    single { DeleteTaskUseCase(get()) }
+    single { DeleteTaskUseCase(get(),get()) }
 }

--- a/src/main/kotlin/domain/usecase/task/CreateTaskUseCase.kt
+++ b/src/main/kotlin/domain/usecase/task/CreateTaskUseCase.kt
@@ -1,10 +1,26 @@
 package org.example.domain.usecase.task
 
+import org.example.data.storage.SessionManger
+import org.example.domain.mapper.toAuditLog
+import org.example.domain.model.AuditLogAction
 import org.example.domain.model.Task
+import org.example.domain.repository.AuditRepository
 import org.example.domain.repository.TaskRepository
 
 class CreateTaskUseCase(
-    private val taskRepository: TaskRepository
+    private val taskRepository: TaskRepository ,
+    private val auditRepository: AuditRepository
 ) {
-    suspend fun createTask(task: Task): Task = taskRepository.createTask(task)
+    suspend fun createTask(task: Task): Task {
+        val createdTask = taskRepository.createTask(task)
+        val auditLog = task.toAuditLog(
+                editor = SessionManger.getUser(),
+                actionType = AuditLogAction.CREATE,
+                changedField = null,
+                oldValue = null,
+                newValue = task.title
+            )
+         auditRepository.createAuditLog(auditLog)
+        return createdTask
+    }
 }

--- a/src/main/kotlin/domain/usecase/task/DeleteTaskUseCase.kt
+++ b/src/main/kotlin/domain/usecase/task/DeleteTaskUseCase.kt
@@ -1,10 +1,29 @@
 package org.example.domain.usecase.task
 
+import org.example.data.storage.SessionManger
+import org.example.domain.mapper.toAuditLog
+import org.example.domain.model.AuditLogAction
 import org.example.domain.model.Task
+import org.example.domain.repository.AuditRepository
 import org.example.domain.repository.TaskRepository
 import java.util.*
 
-class DeleteTaskUseCase(private val taskRepository: TaskRepository) {
+class DeleteTaskUseCase(
+    private val taskRepository: TaskRepository ,
+    private val auditRepository: AuditRepository
+) {
 
-    suspend fun deleteTask(taskId: UUID): Task = taskRepository.deleteTask(taskId)
+    suspend fun deleteTask(taskId: UUID): Task {
+
+        val deletedTask = taskRepository.deleteTask(taskId)
+        val auditLog = deletedTask.toAuditLog(
+                editor = SessionManger.getUser(),
+                actionType = AuditLogAction.DELETE,
+                changedField = null,
+                oldValue = deletedTask.toString(),
+                newValue = ""
+            )
+         auditRepository.createAuditLog(auditLog)
+        return deletedTask
+    }
 }

--- a/src/test/kotlin/domain/usecase/task/CreateTaskUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/task/CreateTaskUseCaseTest.kt
@@ -2,15 +2,20 @@ package domain.usecase.task
 
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.example.data.storage.SessionManger
 import org.example.domain.exception.EiffelFlowException
+import org.example.domain.repository.AuditRepository
 import org.example.domain.repository.TaskRepository
 import org.example.domain.usecase.task.CreateTaskUseCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import utils.TaskMock.validTask
+import utils.UserMock
 import java.io.IOException
 
 
@@ -18,23 +23,31 @@ class CreateTaskUseCaseTest {
 
     private lateinit var createTaskUseCase: CreateTaskUseCase
     private val taskRepository: TaskRepository = mockk()
+    private val auditRepository: AuditRepository = mockk(relaxed = true)
+    private val sessionManger: SessionManger = mockk(relaxed = true)
+
+
 
     @BeforeEach
     fun setUp() {
-        createTaskUseCase = CreateTaskUseCase(taskRepository)
+        createTaskUseCase = CreateTaskUseCase(taskRepository=taskRepository , auditRepository = auditRepository)
     }
 
     @Test
-    fun `createTask should return success when repository returns success`() {
+    fun `should return Created task and create audit log when task is created successfully`() {
         runTest {
+            //Given
+            every { sessionManger.getUser() } returns UserMock.validUser
             coEvery { taskRepository.createTask(validTask) } returns validTask
 
+            //When
             val result = createTaskUseCase.createTask(validTask)
 
             assertThat(result).isEqualTo(validTask)
+            coVerify(exactly = 1) { taskRepository.createTask(validTask) }
+            coVerify(exactly = 1) { auditRepository.createAuditLog(any()) }
         }
     }
-
 
     @Test
     fun `createTask should return failure when repository returns failure`() {

--- a/src/test/kotlin/domain/usecase/task/DeleteTaskUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/task/DeleteTaskUseCaseTest.kt
@@ -3,14 +3,18 @@ package domain.usecase.task
 import com.google.common.truth.Truth.assertThat
 import domain.usecase.task.TaskMock.validTask
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.example.data.storage.SessionManger
 import org.example.domain.exception.EiffelFlowException
+import org.example.domain.repository.AuditRepository
 import org.example.domain.repository.TaskRepository
 import org.example.domain.usecase.task.DeleteTaskUseCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import utils.UserMock
 import java.util.UUID
 
 class DeleteTaskUseCaseTest {
@@ -18,17 +22,22 @@ class DeleteTaskUseCaseTest {
     private lateinit var taskRepository: TaskRepository
     private lateinit var deleteTaskUseCase: DeleteTaskUseCase
     private lateinit var taskIdToDelete: UUID
+    private val auditRepository: AuditRepository = mockk(relaxed = true)
+    private val sessionManger: SessionManger = mockk(relaxed = true)
+
+
 
     @BeforeEach
     fun setUp() {
         taskRepository = mockk()
-        deleteTaskUseCase = DeleteTaskUseCase(taskRepository)
+        deleteTaskUseCase = DeleteTaskUseCase(taskRepository = taskRepository, auditRepository = auditRepository)
         taskIdToDelete = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
     }
 
     @Test
     fun `deleteTask should return success when task exists`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             coEvery { taskRepository.deleteTask(taskIdToDelete) } returns validTask
 
             val result = deleteTaskUseCase.deleteTask(taskIdToDelete)

--- a/src/test/kotlin/domain/usecase/task/EditTaskUseCaseTest.kt
+++ b/src/test/kotlin/domain/usecase/task/EditTaskUseCaseTest.kt
@@ -3,9 +3,11 @@ package domain.usecase.task
 import com.google.common.truth.Truth.assertThat
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
+import org.example.data.storage.SessionManger
 import org.example.domain.model.RoleType
 import org.example.domain.model.TaskState
 import org.example.domain.exception.EiffelFlowException
+import org.example.domain.repository.AuditRepository
 import org.example.domain.repository.TaskRepository
 import org.example.domain.usecase.task.EditTaskUseCase
 import org.junit.jupiter.api.BeforeEach
@@ -13,22 +15,28 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import utils.TaskMock.inProgressTask
 import utils.TaskMock.validTask
+import utils.UserMock
 import java.util.*
 
 class EditTaskUseCaseTest {
 
     private lateinit var taskRepository: TaskRepository
     private lateinit var editTaskUseCase: EditTaskUseCase
+    private val auditRepository: AuditRepository = mockk(relaxed = true)
+    private val sessionManger: SessionManger = mockk(relaxed = true)
+
+
 
     @BeforeEach
     fun setUp() {
         taskRepository = mockk()
-        editTaskUseCase = EditTaskUseCase(taskRepository)
+        editTaskUseCase = EditTaskUseCase(taskRepository = taskRepository , auditRepository = auditRepository)
     }
 
     @Test
     fun `editTask should successfully update task when changes are detected`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             coEvery { taskRepository.getTaskById(inProgressTask.taskId) } returns validTask
             coEvery { taskRepository.updateTask(inProgressTask, validTask, any()) } returns inProgressTask
 
@@ -46,6 +54,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should fail with IOException when no changes detected`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             coEvery { taskRepository.getTaskById(validTask.taskId) } returns validTask
 
             val exception = assertThrows<EiffelFlowException.IOException> {
@@ -71,6 +80,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify title changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(title = "Updated Title")
 
@@ -94,6 +104,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify description changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(description = "Updated description")
 
@@ -117,6 +128,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify assignee changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(assignedId = UUID.randomUUID())
 
@@ -140,6 +152,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify role changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(role = RoleType.ADMIN)
 
@@ -165,6 +178,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify project changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(projectId = UUID.randomUUID())
 
@@ -189,6 +203,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify state changes`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(state = TaskState(name = "in progress"))
 
@@ -229,6 +244,7 @@ class EditTaskUseCaseTest {
     @Test
     fun `editTask should identify when multiple fields are updated`() {
         runTest {
+            every { sessionManger.getUser() } returns UserMock.validUser
             val originalTask = validTask
             val updatedTask = originalTask.copy(
                 title = "Updated Title", description = "Updated Description", assignedId = UUID.randomUUID()


### PR DESCRIPTION
- Move Audit Logs from TaskRepo to Task Use cases
- update Task Use cases
- update Task test cases
- remove Audit Logs from MongoTaskRepositoryImpl
- refactor MongoTaskRepositoryImplTest